### PR TITLE
Fix installation error by upgrading remotedev-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   "dependencies": {
     "chalk": "^2.0.1",
     "minimist": "^1.2.0",
-    "remotedev-server": "^0.2.3"
+    "remotedev-server": "^0.2.4"
   },
   "peerDependencies": {
     "remote-redux-devtools": ">= 0.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1469,6 +1469,10 @@ component-emitter@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.0.tgz#ccd113a86388d06482d03de3fc7df98526ba8efe"
 
+component-emitter@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
+
 compressible@~2.0.10:
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.10.tgz#feda1c7f7617912732b29bf8cf26252a20b9eecd"
@@ -3789,12 +3793,11 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
-ncom@~0.11.1:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/ncom/-/ncom-0.11.1.tgz#e41f98a13c486d353f11e967217657cecc81329b"
+ncom@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ncom/-/ncom-1.0.0.tgz#9d024905a9e86cffab3fb233ff661e3e7ba75a65"
   dependencies:
-    sc-domain "1.x.x"
-    sc-formatter "3.0.x"
+    sc-formatter "~3.0.0"
 
 nearley@^2.7.7:
   version "2.10.1"
@@ -5020,9 +5023,9 @@ remotedev-monitor-components@^0.0.5:
     codemirror "^5.21.0"
     styled-components "^1.1.1"
 
-remotedev-server@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/remotedev-server/-/remotedev-server-0.2.3.tgz#dcaaf64987557b5d06a44e4e18c36308d88ea980"
+remotedev-server@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/remotedev-server/-/remotedev-server-0.2.4.tgz#b019b015132064cd76024cb91eb026801f24cd67"
   dependencies:
     body-parser "^1.15.0"
     chalk "^1.1.3"
@@ -5037,7 +5040,7 @@ remotedev-server@^0.2.3:
     object-assign "^4.0.0"
     repeat-string "^1.5.4"
     semver "^5.3.0"
-    socketcluster "^5.0.4"
+    socketcluster "^6.7.1"
 
 remotedev-slider@1.1.3:
   version "1.1.3"
@@ -5194,33 +5197,32 @@ sax@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
-sc-auth@~4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/sc-auth/-/sc-auth-4.1.0.tgz#395b2ec525c15a7754ada410cc258480619104ce"
+sc-auth@~4.1.1:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/sc-auth/-/sc-auth-4.1.2.tgz#6a11289826febe09c552e38468a22c08cef61eb9"
   dependencies:
-    sc-errors "~1.3.0"
+    sc-errors "~1.3.3"
     sc-jsonwebtoken "~7.4.2"
 
-sc-broker-cluster@~4.0.0:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/sc-broker-cluster/-/sc-broker-cluster-4.0.3.tgz#59c03b31c396df4410e6d198ba50ec0740508f0f"
+sc-broker-cluster@~4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/sc-broker-cluster/-/sc-broker-cluster-4.3.0.tgz#a82526385aa382400737512090328f4cb659b8e0"
   dependencies:
     async "2.0.0"
-    sc-broker "~3.0.0"
-    sc-channel "~1.0.6"
-    sc-domain "~1.0.1"
-    sc-errors "~1.3.0"
+    sc-broker "~4.1.0"
+    sc-channel "~1.1.0"
+    sc-errors "~1.3.3"
     sc-hasher "~1.0.0"
 
-sc-broker@~3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/sc-broker/-/sc-broker-3.0.0.tgz#a34491816bdc2aaf6f23562c942eb9505eb5477d"
+sc-broker@~4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/sc-broker/-/sc-broker-4.1.0.tgz#4e0d5949126542bc00fabc9d897b56e308d9738a"
   dependencies:
     expirymanager "~0.9.3"
     fleximap "~0.9.10"
-    ncom "~0.11.1"
-    sc-domain "~1.0.1"
-    sc-errors "~1.3.0"
+    ncom "~1.0.0"
+    sc-errors "~1.3.3"
+    uuid "3.1.0"
 
 sc-channel@~1.0.6:
   version "1.0.6"
@@ -5228,9 +5230,11 @@ sc-channel@~1.0.6:
   dependencies:
     sc-emitter "1.x.x"
 
-sc-domain@1.x.x, sc-domain@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/sc-domain/-/sc-domain-1.0.1.tgz#aa402509b879ba76012e9732dc1d07f653b834bc"
+sc-channel@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/sc-channel/-/sc-channel-1.1.0.tgz#8058b2bd630df84888cae70dd41414eafa468a81"
+  dependencies:
+    component-emitter "1.2.1"
 
 sc-emitter@1.x.x, sc-emitter@~1.1.0:
   version "1.1.0"
@@ -5242,7 +5246,11 @@ sc-errors@~1.3.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/sc-errors/-/sc-errors-1.3.2.tgz#3b00b852d2f081a95196a57f541539c61aaf3b41"
 
-sc-formatter@3.0.x, sc-formatter@~3.0.0:
+sc-errors@~1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/sc-errors/-/sc-errors-1.3.3.tgz#c00bc4c766a970cc8d5937d08cd58e931d7dae05"
+
+sc-formatter@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/sc-formatter/-/sc-formatter-3.0.0.tgz#c91b1fe56c260abd5a6a2e6af98c724bc7998a38"
 
@@ -5260,11 +5268,11 @@ sc-jsonwebtoken@~7.4.2:
     ms "^2.0.0"
     xtend "^4.0.1"
 
-sc-simple-broker@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/sc-simple-broker/-/sc-simple-broker-2.0.0.tgz#2de6fd35235a0b76d7ae6349d1c7f9dd1e18091c"
+sc-simple-broker@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/sc-simple-broker/-/sc-simple-broker-2.1.0.tgz#bcdb23884038756455eb2723bdf6f551296c6eed"
   dependencies:
-    sc-channel "~1.0.6"
+    sc-channel "~1.1.0"
 
 schema-utils@^0.3.0:
   version "0.3.0"
@@ -5399,40 +5407,37 @@ socketcluster-client@^5.5.0:
     sc-formatter "~3.0.0"
     ws "3.0.0"
 
-socketcluster-server@~5.15.0:
-  version "5.15.0"
-  resolved "https://registry.yarnpkg.com/socketcluster-server/-/socketcluster-server-5.15.0.tgz#142025fe687d99e786317a5db5fd6398bb9f0fb1"
+socketcluster-server@~6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/socketcluster-server/-/socketcluster-server-6.3.0.tgz#7a1fcc8933e53e1654048bc36b36fc3ae12aed6b"
   dependencies:
     async "2.0.0"
     base64id "0.1.0"
+    component-emitter "1.2.1"
     lodash.clonedeep "4.5.0"
-    sc-auth "~4.1.0"
-    sc-domain "~1.0.1"
-    sc-emitter "~1.1.0"
-    sc-errors "~1.3.0"
+    sc-auth "~4.1.1"
+    sc-errors "~1.3.3"
     sc-formatter "~3.0.0"
-    sc-simple-broker "~2.0.0"
-    uuid "3.0.1"
+    sc-simple-broker "~2.1.0"
+    uuid "3.1.0"
     uws "8.14.0"
-    ws "3.0.0"
+    ws "3.1.0"
 
-socketcluster@^5.0.4:
-  version "5.16.0"
-  resolved "https://registry.yarnpkg.com/socketcluster/-/socketcluster-5.16.0.tgz#e228a1af473c1cac7c308e5eeea11610616f74be"
+socketcluster@^6.7.1:
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/socketcluster/-/socketcluster-6.8.0.tgz#41cf838b0ba982eefdd8e8051967b76e39d7ee73"
   dependencies:
     async "2.0.0"
     base64id "0.1.0"
     fs-extra "2.0.0"
     inquirer "1.1.3"
     minimist "1.1.0"
-    sc-auth "~4.1.0"
-    sc-broker-cluster "~4.0.0"
-    sc-domain "~1.0.1"
-    sc-emitter "~1.1.0"
-    sc-errors "~1.3.0"
-    socketcluster-server "~5.15.0"
+    sc-auth "~4.1.1"
+    sc-broker-cluster "~4.3.0"
+    sc-errors "~1.3.3"
+    socketcluster-server "~6.3.0"
     uid-number "0.0.5"
-    uuid "3.0.1"
+    uuid "3.1.0"
 
 sockjs-client@1.1.2:
   version "1.1.2"
@@ -5945,13 +5950,17 @@ utils-merge@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.0.tgz#0294fb922bb9375153541c4f7096231f287c8af8"
 
-uuid@3.0.1, uuid@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
+uuid@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 
 uuid@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
+
+uuid@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
 
 uws@8.14.0:
   version "8.14.0"
@@ -6141,6 +6150,13 @@ ws@3.0.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-3.0.0.tgz#98ddb00056c8390cb751e7788788497f99103b6c"
   dependencies:
     safe-buffer "~5.0.1"
+    ultron "~1.1.0"
+
+ws@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-3.1.0.tgz#8afafecdeab46d572e5397ee880739367aa2f41c"
+  dependencies:
+    safe-buffer "~5.1.0"
     ultron "~1.1.0"
 
 xtend@^4.0.0, xtend@^4.0.1:


### PR DESCRIPTION
With a fresh yarn or npm cache, `remotedev-rn-debugger` cannot be installed. Yarn fails with 

    error An unexpected error occurred: "https://registry.yarnpkg.com/uws/-/uws-0.13.0.tgz: Request failed \"404 Not Found\"".

The problem is that `uws@0.13.0` has been removed from yarn/npm (they call it archived here https://github.com/uNetworking/uWebSockets/releases) and `socketcluster@5.x` depends on `uws@0.13.0`...

It doesn't look like the breaking changes in socketcluster@6 will have any effect. See https://github.com/SocketCluster/socketcluster/releases/tag/v6.0.1

See https://github.com/zalmoxisus/remotedev-server/pull/45#event-1237438733
